### PR TITLE
update trenchbroom_player_point

### DIFF
--- a/src/demo_doer/demo_to_pointfile.rs
+++ b/src/demo_doer/demo_to_pointfile.rs
@@ -3,7 +3,7 @@ use crate::open_demo;
 use super::*;
 use std::{fs::File, io::Write, path::Path};
 
-pub fn trenchbroom_player_point(demo: &Demo) {
+pub fn demo_to_pointfile(demo: &Demo) {
     let ghost = get_ghost::demo::demo_ghost_parse("trenchbroom", demo, 0., false);
     let mut file = File::create("trenchbroom_player_point.txt").unwrap();
 
@@ -21,7 +21,7 @@ pub fn trenchbroom_player_point(demo: &Demo) {
     }
 }
 
-pub fn trenchbroom_player_point_cli() {
+pub fn demo_to_pointfile_cli() {
     use std::env;
 
     let help = || {
@@ -36,7 +36,7 @@ Output file is \"trenchbroom_player_point.txt\"
     let wrap = |demo_file_name: &str| {
         let demo_file_name = Path::new(demo_file_name);
         let demo = open_demo!(demo_file_name);
-        trenchbroom_player_point(&demo);
+        demo_to_pointfile(&demo);
     };
 
     let args: Vec<String> = env::args().collect();

--- a/src/demo_doer/demo_to_pointfile.rs
+++ b/src/demo_doer/demo_to_pointfile.rs
@@ -3,13 +3,16 @@ use crate::open_demo;
 use super::*;
 use std::{fs::File, io::Write, path::Path};
 
-pub fn demo_to_pointfile(demo: &Demo) {
-    let ghost = get_ghost::demo::demo_ghost_parse("trenchbroom", demo, 0., false);
-    let mut file = File::create("trenchbroom_player_point.txt").unwrap();
+
+/// Generates a pointfile (.pts) to visualize the player's path within the level editor
+/// The pointfile can be loaded into JACK or Trenchbroom
+pub fn demo_to_pointfile(demo: &Demo, output_name: &str) {
+    let ghost = get_ghost::demo::demo_ghost_parse("player_path", demo, 0., false);
+    let mut pointfile = File::create(format!("{}.pts", output_name)).unwrap();
 
     for frame in ghost.frames {
         match write!(
-            file,
+            pointfile,
             "{} {} {}\n",
             frame.origin[0], frame.origin[1], frame.origin[2]
         ) {
@@ -27,16 +30,20 @@ pub fn demo_to_pointfile_cli() {
     let help = || {
         println!(
             "\
-Output file is \"trenchbroom_player_point.txt\"
+Poinfile will be generated based on the demo file name.
+If the demo file is 'bkz_goldbhop.dem', the output file will be 'bkz_goldbhop.pts'
 
-./binary <path to demo>"
+Usage:
+  ./binary <path to demo>"
         )
     };
 
     let wrap = |demo_file_name: &str| {
         let demo_file_name = Path::new(demo_file_name);
         let demo = open_demo!(demo_file_name);
-        demo_to_pointfile(&demo);
+        let point_file_name = demo_file_name.file_stem().unwrap().to_str().unwrap();
+        demo_to_pointfile(&demo, &point_file_name);
+        println!("Pointfile successfully generated: {}", point_file_name);
     };
 
     let args: Vec<String> = env::args().collect();

--- a/src/demo_doer/mod.rs
+++ b/src/demo_doer/mod.rs
@@ -18,7 +18,7 @@ pub mod netmsg_rewrite_test;
 pub mod offset_viewangles;
 pub mod remove_entities;
 pub mod superimpose;
-pub mod trenchbroom_player_point;
+pub mod demo_to_pointfile;
 
 // use bitvec::bitvec;
 // use bitvec::prelude::*;


### PR DESCRIPTION
Updated the function to bring support for JACK. Since JACK doesn't load .txt
Renamed `trenchbroom_player_point` -> `demo_to_pointfile`
Now generate `.pts` file instead of `.txt`